### PR TITLE
Building slackbot rebased: Integration with github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.swp
+vendor/
+build
+github_token
+slack_token

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build tidy clean
+
+build:
+	@echo "make build:"
+	go build -o build/issuebot
+
+clean:
+	@echo "make clean:"
+	-rm -r build/*
+
+# Add files here that you want to be checked before building w/ tools in "tidy" target below
+FILES := main.go 
+
+tidy:$(FILES)
+	gofmt -w $?
+	# TODO: govet?
+
+
+
+# TODO: build, install, clean, test
+# TODO: 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build tidy clean
+.PHONY: build tidy clean test
 
 build:
 	@echo "make build:"
@@ -8,8 +8,12 @@ clean:
 	@echo "make clean:"
 	-rm -r build/*
 
+test:
+	@echo "make test (expand this w/ hello):"
+	go test
+
 # Add files here that you want to be checked before building w/ tools in "tidy" target below
-FILES := main.go 
+FILES := main.go main_test.go
 
 tidy:$(FILES)
 	gofmt -w $?

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 	go test
 
 # Add files here that you want to be checked before building w/ tools in "tidy" target below
-FILES := main.go main_test.go
+FILES := main.go main_test.go flags.go flags_test.go slack.go slack_test.go github.go github_test.go
 
 tidy:$(FILES)
 	gofmt -w $?

--- a/PROJECT_MANAGEMENT.md
+++ b/PROJECT_MANAGEMENT.md
@@ -7,7 +7,7 @@
 | -------------:|:-------------:| ----:|
 | Early research | -- | Done @ 2:00 |
 | PM timing | 30 min | Done @ 0:35 |
-| Look at commenting documentation | 30 min max | Pending |
+| Look at commenting documentation | 30 min max | Done @ 0:20 |
 | Look at slack documentation (the one Sasha recommend shama11?) | 30 min max | Pending |
 | Look at github docs (google repo) | 30 min max | Pending |
 | Look at x/oauth (apparently both slack and github use oauth) | 45 min budgeted | Pending |
@@ -27,7 +27,7 @@
 | Write success unittest for internal functions | 1 hr | Pending |
 | Write common error unittests for internal functions | SKIP for PoC | Pending |
 | Write fuzzers for internal functions | SKIP for PoC |  Pending |
-| Total | 13:05 Estimated | 2:35 Completed |
+| Total | 8:35 Left | 2:55 Completed |
 
 Comment as you go along in godoc-friendly style
 

--- a/PROJECT_MANAGEMENT.md
+++ b/PROJECT_MANAGEMENT.md
@@ -16,7 +16,7 @@
 | Catch signals to set a healthy exit | 10 min | Done @ 0:24 |
 | Set up flag module to take in flags | 15 min | Done @ 0:30 |
 | Error checking on flags/sanitizing/sanity check | Basics only, 15 min | Done @ 0:00 |
-| Input file to array for user auth | 25 min | Pending |
+| Input file to array for user auth | 25 min | Done @ 0:41 |
 | Write function to sanity test slack connection | 45 min | Pending |
 | Write function to sanity test github conneciton + org validity | 45 min | Pending |
 | Set up retry function so we can reconnect after init | 30 min | Pending |
@@ -24,10 +24,10 @@
 | Write callback to get info from slack (and print to log) | 30 min | Pending |
 | Write function to get issue onto github w/ proper returns | 1 hr | Pending |
 | Write function to respond to slack |  30 min | Pending |
-| Write success unittest for internal functions | 1 hr | Pending |
-| Write common error unittests for internal functions | SKIP for PoC | Pending |
+| Write success unittest for internal functions | 1 hr | Pending @ 3:00 |
+| Write common error unittests for internal functions | SKIP for PoC | Rolled into success w/ unit test tables |
 | Write fuzzers for internal functions | SKIP for PoC |  Pending |
-| Total | 8:35 Left | 2:55 Completed |
+| Total | 4:00 Left | 9:30 Completed |
 
 Comment as you go along in godoc-friendly style
 

--- a/PROJECT_MANAGEMENT.md
+++ b/PROJECT_MANAGEMENT.md
@@ -8,14 +8,14 @@
 | Early research | -- | Done @ 2:00 |
 | PM timing | 30 min | Done @ 0:35 |
 | Look at commenting documentation | 30 min max | Done @ 0:20 |
-| Look at slack documentation (the one Sasha recommend shama11?) | 30 min max | Pending |
-| Look at github docs (google repo) | 30 min max | Pending |
-| Look at x/oauth (apparently both slack and github use oauth) | 45 min budgeted | Pending |
-| Set up a development/testing environment | 30 min budgeted | Pending |
-| Set up dep manager (vgo? godep? go mod? whatever is easier) | 45 min budgeted | Pending |
-| Catch signals to set a healthy exit | 10 min | Pending |
-| Set up flag module to take in flags | 15 min | Pending |
-| Error checking on flags/sanitizing/sanity check | Basics only, 15 min | Pending |
+| Look at slack documentation (the one Sasha recommend shama11?) | 30 min max | Done @ 0:37 |
+| Look at github docs (google repo) | 30 min max | Done @ 0:23 |
+| Look at x/oauth (apparently both slack and github use oauth) | 45 min budgeted | Done @ 0:00 |
+| Set up a development/testing environment | 30 min budgeted | Done @ 1:01 |
+| Set up dep manager (vgo? godep? go mod? whatever is easier) | 45 min budgeted | Done @ 0:00 |
+| Catch signals to set a healthy exit | 10 min | Done @ 0:24 |
+| Set up flag module to take in flags | 15 min | Done @ 0:30 |
+| Error checking on flags/sanitizing/sanity check | Basics only, 15 min | Done @ 0:00 |
 | Input file to array for user auth | 25 min | Pending |
 | Write function to sanity test slack connection | 45 min | Pending |
 | Write function to sanity test github conneciton + org validity | 45 min | Pending |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,51 @@
 # issuebot
 
-Issuebot is a slackbot that allows creating new github issues with a command
+**issuebot** is a slackbot that allows creating new github issues with a command
+
+# Building
+
+_Hint: `git clone` this repo to your `$GOPATH/src` directory; `go help gopath` and `go help importpath` for more info`_
+
+Make commands (may be more in _Makefile_): 
+
+`make build (default)`  
+Outputs binary to _./build/_
+
+`make tidy`  
+Runs `gofmt` and `govet` on files specified in Makefile's _FILE_ variable
+
+`make test`  
+Runs `go test` as expected
+
+`make clean`  
+Clears _./build/_ directory
+
+
+## Dependencies
+
+This is a list of 3rd party dependencies, which you can load with `go get` or migrate to your organization's dep management system.
+
+[github.com/shomali11/slacker](https://github.com/shomali11/slacker)  
+A simple library that allows you to create slackbots by registering a command string and a callback
+
+[github.com/shurcooL/githubv4](https://github.com/shomali11/slacker)  
+An extensive library that creates a go interfaces for the GitHub APIv4 (graphQL)
+
+[golang.org/x/oauth2](https://godoc.org/golang.org/x/oauth2)  
+The oauth library used by githubv4 for auth
+
+# After Building: Configure and Run
+
+* Create a slack token (refer to slack docs)
+* Create a github token (refer to github docs)  
+_NB: as of Feb 2019, this can be the personal or the "oauth"- effectively the same (oath), but "oath" registers your "app"_
+* Create two files with just the tokens (or override w/ flag-- see below):
+  * slack_token
+  * github_token
+* Create a file and list slack users (**BY WHAT**), each on a new line, who can use the issuebot. This will be specified on the command line.
+* Run the program (see below for normal flags or use --help)  in ./build and it will do it's best to connect
+
+# Using with Slack
 
 # Preliminary Design Summary
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 **issuebot** is a slackbot that allows creating new github issues with a command
 
-# Building
+## Building
 
-_Hint: `git clone` this repo to your `$GOPATH/src` directory; `go help gopath` and `go help importpath` for more info`_
+_Hint: `git clone` this repo to your `$GOPATH/src` directory; `go help gopath` and `go help importpath` for more info_
 
-Make commands (may be more in _Makefile_): 
+Make commands (there may be more in _Makefile_): 
 
-`make build (default)`  
-Outputs binary to _./build/_
+`make build` 
+Outputs binary to _./build/_. This is the default make target.
 
 `make tidy`  
 Runs `gofmt` and `govet` on files specified in Makefile's _FILE_ variable
@@ -21,73 +21,36 @@ Runs `go test` as expected
 Clears _./build/_ directory
 
 
-## Dependencies
+### Dependencies
 
-This is a list of 3rd party dependencies, which you can load with `go get` or migrate to your organization's dep management system.
+This is a list of 3rd party dependencies, which you can load with `go get` or migrate manually to your organization's dependency management system.
 
 [github.com/shomali11/slacker](https://github.com/shomali11/slacker)  
 A simple library that allows you to create slackbots by registering a command string and a callback
 
 [github.com/shurcooL/githubv4](https://github.com/shomali11/slacker)  
-An extensive library that creates a go interfaces for the GitHub APIv4 (graphQL)
+An extensive library that creates a go interface for the GitHub APIv4 (GraphQL)
 
 [golang.org/x/oauth2](https://godoc.org/golang.org/x/oauth2)  
-The oauth library used by githubv4 for auth
+The oauth library used by GitHub APIv4 for auth
 
-# After Building: Configure and Run
+[github.com/mailgun/log](https://github.com/mailgun/log)  
+The logger used by this programmer
+
+[gopkg.in/check.v1](https://gopkg.in/check.v1)  
+A testing suite to enhance Go's native "testing" module
+
+## After Building: Configure and Run
 
 * Create a slack token (refer to slack docs)
 * Create a github token (refer to github docs)  
 _NB: as of Feb 2019, this can be the personal or the "oauth"- effectively the same (oath), but "oath" registers your "app"_
-* Create two files with just the tokens (or override w/ flag-- see below):
+* Create two files with just the tokens (or override these w/ one of two flags-- see flags with `issuebot --help`):
   * slack_token
   * github_token
-* Create a file and list slack users (**BY WHAT**), each on a new line, who can use the issuebot. This will be specified on the command line.
-* Run the program (see below for normal flags or use --help)  in ./build and it will do it's best to connect
+* Create a file and list slack users (**BY WHAT**), each on a new line, who can use the issuebot. The default file name is *./userlist* but can be overrided by a flag.
+* Run the program (see below for typical use or use `issuebot --help` to see all flags) in _./build/_ and it will do it's best to connect
 
-# Using with Slack
+The benefit of using files for keys and users is that the files can be reloaded by with <kbd>^C</kbd>. Hit <kbd>^C</kbd> twice to exit cleanly.
 
-# Preliminary Design Summary
-
-## Objective
-
-Using https://godoc.org/github.com/shomali11/slacker (recommended by Sasha), I’m writing a Golang process that functions as a slackbot to post new github issues. The slackbot will listen for mentions (or private messages) and take a command and two string parameters in slack. The first string parameter is a repository, the second string parameter is text. This will become a new github issue, and the bot will reply with link or failure. When starting the process, specify a slack key, a github organization or user, and a newline-delimited list of authorized slack users.
-
-### Example in CLI:
-
-```
-$: ./issuebot --org=gravitational --auth=./userlist --slack-token=SLACK_TOKEN --github-token=GITHUB_TOKEN
-...connecting to slack… success
-...pinging github api… success
-...looking for userlist… success
-...looking for organization… success
-(other basic logging)
-```
-
-<kbd>^C</kbd>: will give option to reload authed users or quit cleanly (ie stop accepting commands and finish whatever is in queue)  
-<kbd>^C ^C</kbd>: get out as fast as possible (kill, not necessarily waiting for network to finish)
-
-### Example in Slack:
-
-**ayjay_t:**  
-@issuebot new teleport Won’t compile on atari  
-**issuebot:**  
-Success: https://github.com/nlopes/slack/issues/460  
-
-Or
-
-**ayjay_t:**  
-/msg @issuebot new issuebot Need to authenticate with SSO  
-**issuebot:**  
-Failure: Network error | No/Bad Repo | etc  
-
-(if I can do custom commands I guess I will? `/issue new` makes sense if it’s easy- will assess)
-
-## Basic Architecture:
-
-The program will be a simple loop (after an init) that listens on slack and then dispatches to linux. The slack uses a callback like structure, so hopefully this is asynchronous.
-You can see the *PROJECT_MANAGEMENT.md* file for more information about the approach- a lot of it is specific to the api's being used.
-
-## Misc
-
-[Gravitational Issue Template](https://github.com/gravitational/teleport/blob/master/docs/ISSUE_TEMPLATE.md)
+## Using with Slack

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # issuebot
 
-**issuebot** is a slackbot that allows creating new github issues with a command
+**issuebot** is a slackbot that allows creating new github issues with a command.
+
+NB: It runs under a single user, and you can only have it write to one organization at this time.
 
 ## Building
 
@@ -52,3 +54,19 @@ You must specify `--org "org name or user name"` so that IssueBot knows where to
 The benefit of using files for tokens and users is that the files can be reloaded by with <kbd>^C</kbd>. Hit <kbd>^C</kbd> twice to exit cleanly.
 
 ## Using with Slack
+
+`new "REPO_NAME" "ISSUE_TITLE" "ISSUE_BODY"`
+
+Quotes are required. You can escape quotes with a backslash. (Any character following a backslash is treated as ascii)
+
+**ayjay_t:**  
+@issuebot new "teleport" "Support Platform: Atari" "It won’t compile on Atari due to whatever"
+**issuebot:**  
+Success: https://github.com/nlopes/slack/issues/460  
+
+Or
+
+**ayjay_t:**  
+/msg @issuebot new "issuebot" "Feature Addition" "Need to authenticate with SSO"
+**issuebot:**  
+Failure: Network error | No/Bad Repo | etc  

--- a/README.md
+++ b/README.md
@@ -4,26 +4,19 @@
 
 ## Building
 
+There is a list of dependencies below- you can use your own dep manager or just use `go get`
+
 _Hint: `git clone` this repo to your `$GOPATH/src` directory; `go help gopath` and `go help importpath` for more info_
 
-Make commands (there may be more in _Makefile_): 
+### Make commands (more in _Makefile_): 
 
-`make build` 
+`make build`  
 Outputs binary to _./build/_. This is the default make target.
-
-`make tidy`  
-Runs `gofmt` and `govet` on files specified in Makefile's _FILE_ variable
 
 `make test`  
 Runs `go test` as expected
 
-`make clean`  
-Clears _./build/_ directory
-
-
 ### Dependencies
-
-This is a list of 3rd party dependencies, which you can load with `go get` or migrate manually to your organization's dependency management system.
 
 #### Run
 
@@ -53,8 +46,9 @@ _NB: as of Feb 2019, this can be the personal or the "oauth"- effectively the sa
   * slack_token
   * github_token
 * Create a file and list slack users (**BY WHAT**), each on a new line, who can use the issuebot. The default file name is *./userlist* but can be overrided by a flag.
-* Run the program (see below for typical use or use `issuebot --help` to see all flags) in _./build/_ and it will do it's best to connect
+* Run the program (see below for typical use or use `issuebot --help` to see all flags) in _./build/_ and it will do it's best to connect:
+You must specify `--org "org name or user name"` so that IssueBot knows where to find repo's specified by the user.
 
-The benefit of using files for keys and users is that the files can be reloaded by with <kbd>^C</kbd>. Hit <kbd>^C</kbd> twice to exit cleanly.
+The benefit of using files for tokens and users is that the files can be reloaded by with <kbd>^C</kbd>. Hit <kbd>^C</kbd> twice to exit cleanly.
 
 ## Using with Slack

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ The logger used by this programmer
 [gopkg.in/check.v1](https://gopkg.in/check.v1)  
 A testing suite to enhance Go's native "testing" module
 
-[github.com/ayjayt/crashtest](https://github.com/ayjayt/crashtest)
-A helper library to catch functions that panic or exit and test for error codes
-
 ## After Building: Configure and Run
 
 * Create a slack token (refer to slack docs)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Clears _./build/_ directory
 
 This is a list of 3rd party dependencies, which you can load with `go get` or migrate manually to your organization's dependency management system.
 
+#### Run
+
 [github.com/shomali11/slacker](https://github.com/shomali11/slacker)  
 A simple library that allows you to create slackbots by registering a command string and a callback
 
@@ -37,8 +39,13 @@ The oauth library used by GitHub APIv4 for auth
 [github.com/mailgun/log](https://github.com/mailgun/log)  
 The logger used by this programmer
 
+#### Test
+
 [gopkg.in/check.v1](https://gopkg.in/check.v1)  
 A testing suite to enhance Go's native "testing" module
+
+[github.com/ayjayt/crashtest](https://github.com/ayjayt/crashtest)
+A helper library to catch functions that panic or exit and test for error codes
 
 ## After Building: Configure and Run
 

--- a/doc/original_concept.md
+++ b/doc/original_concept.md
@@ -1,0 +1,45 @@
+# Preliminary Design Summary
+
+## Objective
+
+Using https://godoc.org/github.com/shomali11/slacker (recommended by Sasha), I’m writing a Golang process that functions as a slackbot to post new github issues. The slackbot will listen for mentions (or private messages) and take a command and two string parameters in slack. The first string parameter is a repository, the second string parameter is text. This will become a new github issue, and the bot will reply with link or failure. When starting the process, specify a slack key, a github organization or user, and a newline-delimited list of authorized slack users.
+
+### Example in CLI:
+
+```
+$: ./issuebot --org=gravitational --auth=./userlist --slack-token=SLACK_TOKEN --github-token=GITHUB_TOKEN
+...connecting to slack… success
+...pinging github api… success
+...looking for userlist… success
+...looking for organization… success
+(other basic logging)
+```
+
+<kbd>^C</kbd>: will give option to reload authed users or quit cleanly (ie stop accepting commands and finish whatever is in queue)  
+<kbd>^C ^C</kbd>: get out as fast as possible (kill, not necessarily waiting for network to finish)
+
+### Example in Slack:
+
+**ayjay_t:**  
+@issuebot new teleport Won’t compile on atari  
+**issuebot:**  
+Success: https://github.com/nlopes/slack/issues/460  
+
+Or
+
+**ayjay_t:**  
+/msg @issuebot new issuebot Need to authenticate with SSO  
+**issuebot:**  
+Failure: Network error | No/Bad Repo | etc  
+
+(if I can do custom commands I guess I will? `/issue new` makes sense if it’s easy- will assess)
+
+## Basic Architecture:
+
+The program will be a simple loop (after an init) that listens on slack and then dispatches to linux. The slack uses a callback like structure, so hopefully this is asynchronous.
+You can see the *PROJECT_MANAGEMENT.md* file for more information about the approach- a lot of it is specific to the api's being used.
+
+## Misc
+
+[Gravitational Issue Template](https://github.com/gravitational/teleport/blob/master/docs/ISSUE_TEMPLATE.md)
+

--- a/flags.go
+++ b/flags.go
@@ -103,30 +103,46 @@ func loadAuthedUsers() (ret []string, err error) {
 	return ret, nil
 }
 
-// loadSlackKey tries to return a slack key (from flag or file)
+// loadSlackTokentries to return a slack key (from flag or file)
 // This function reads from globals (flags)
-func loadSlackKey() (slack string, err error) {
+func loadSlackToken() (slack string, err error) {
 	if *flag_slack_token == "" {
 		slackFileContents, err := ioutil.ReadFile(*flag_slack_token_file)
 		if err != nil {
 			return "", err
 		}
 		slack = string(slackFileContents)
+
+		// BUG(AJ) I just don't like this
+		if strings.HasSuffix(slack, "\r\n") {
+			log.Warningf("Slack Token ends in whitespace, eliminating two characters (\\r\\n)...")
+			slack = strings.TrimSuffix(slack, "\r\n")
+		} else if strings.HasSuffix(slack, "\n") {
+			log.Warningf("Slack Token ends in whitespace, eliminating one character (\\n)...")
+			slack = strings.TrimSuffix(slack, "\n")
+		}
 	} else {
 		slack = *flag_slack_token
 	}
 	return slack, nil
 }
 
-// loadGitHubKey tries to return a github key (from flag or file)
+// loadGitHubToken tries to return a github key (from flag or file)
 // This function reads from globals (flags)
-func loadGitHubKey() (github string, err error) {
+func loadGitHubToken() (github string, err error) {
 	if *flag_github_token == "" {
 		githubFileContents, err := ioutil.ReadFile(*flag_github_token_file)
 		if err != nil {
 			return "", err
 		}
 		github = string(githubFileContents)
+		if strings.HasSuffix(github, "\r\n") {
+			log.Warningf("GitHub Token ends in whitespace, eliminating two characters (\\r\\n)...")
+			github = strings.TrimSuffix(github, "\r\n")
+		} else if strings.HasSuffix(github, "\n") {
+			log.Warningf("GitHub Token ends in whitespace, eliminating one character (\\n)...")
+			github = strings.TrimSuffix(github, "\n")
+		}
 	} else {
 		github = *flag_slack_token
 	}

--- a/flags.go
+++ b/flags.go
@@ -98,9 +98,9 @@ func loadAuthedUsers() (ret []string, err error) {
 	}
 	ret = strings.Split(string(authFile), "\r\n")
 	if len(ret) == 1 { // it's possible that different OSes have different newline conventions- don't check \n first
-		ret = strings.Split(string(authFile), "\n")
+		ret = strings.Split(ret[0], string(10)) // this is catching a space?
 	}
-	return ret, nil
+	return ret[:len(ret)-1], nil
 }
 
 // loadSlackTokentries to return a slack key (from flag or file)

--- a/flags.go
+++ b/flags.go
@@ -11,40 +11,40 @@ import (
 // these vars make checking if flags were set easier than using the flag pkg default
 // they can't be const because golang wants to optimize them away but we use their addresses
 var (
-	DEFAULT_SLACK_TOKEN_FILE  = "./slack_token"
-	DEFAULT_GITHUB_TOKEN_FILE = "./github_token"
+	DefaultSlackTokenFile  = "./slack_token"
+	DefaultGitHubTokenFile = "./github_token"
 )
 var (
 	ErrBadFlag = errors.New("command was run improperly, check --help")
 )
 var (
-	// flag_org is the name of the org the bot has access to
-	flag_org = flag.String("org",
+	// flagOrg is the name of the org the bot has access to
+	flagOrg = flag.String("org",
 		"",
 		"Organization bot has access to")
 
-	// flag_auth provides a file by which to load authorized users
-	flag_auth = flag.String("auth",
+	// flagAuth provides a file by which to load authorized users
+	flagAuth = flag.String("auth",
 		"./userlist",
 		"What file contains a list of authorized users")
 
-	// flag_slack_token will provide a slack token manually
-	flag_slack_token = flag.String("slack_token",
+	// flagSlackToken will provide a slack token manually
+	flagSlackToken = flag.String("slack_token",
 		"",
 		"Specify the slack token")
 
 	// github_token will provide a github token manually
-	flag_github_token = flag.String("github_token",
+	flagGitHubToken = flag.String("github_token",
 		"",
 		"Specify the github oauth token")
 
-	// flag_slack_token_file will provide a filename for a slack token
-	flag_slack_token_file = flag.String("slack_token_file",
+	// flagSlackTokenFile will provide a filename for a slack token
+	flagSlackTokenFile = flag.String("slack_token_file",
 		"",
 		"Specify the slack token file")
 
 	// github_token_file will provide a filename for a github token
-	flag_github_token_file = flag.String("github_token_file",
+	flagGitHubTokenFile = flag.String("github_token_file",
 		"",
 		"Specify the github oauth token file")
 )
@@ -61,38 +61,38 @@ func flagInit() (err error) {
 // verifyFlagsSanity just does a basic check on provided flags- are the ones that need to be there, there?
 // This function reads from globals (flags)
 func verifyFlagsSanity() (err error) {
-	if len(*flag_org) == 0 {
+	if len(*flagOrg) == 0 {
 		log.Errorf("You must specify an organization, see --help")
 		err = ErrBadFlag
 	}
-	if *flag_slack_token_file == "" {
-		if *flag_slack_token == "" {
-			flag_slack_token_file = &DEFAULT_SLACK_TOKEN_FILE
+	if *flagSlackTokenFile == "" {
+		if *flagSlackToken == "" {
+			flagSlackTokenFile = &DefaultSlackTokenFile
 		}
 	} else {
-		if *flag_slack_token != "" {
-			log.Errorf("You must not specify both --flag_slack_token_file AND --flag_slack_token, see --help")
+		if *flagSlackToken != "" {
+			log.Errorf("You must not specify both --flagSlackTokenFile AND --flagSlackToken, see --help")
 			err = ErrBadFlag
 		}
 	}
-	if *flag_github_token_file == "" {
-		if *flag_github_token == "" {
-			flag_github_token_file = &DEFAULT_GITHUB_TOKEN_FILE
+	if *flagGitHubTokenFile == "" {
+		if *flagGitHubToken == "" {
+			flagGitHubTokenFile = &DefaultGitHubTokenFile
 		}
 	} else {
-		if *flag_github_token != "" {
-			log.Errorf("You must not specify both --flag_github_token_file AND --flag_github_token, see --help")
+		if *flagGitHubToken != "" {
+			log.Errorf("You must not specify both --flagGitHubTokenFile AND --flagGitHubToken, see --help")
 			err = ErrBadFlag
 		}
 	}
 	return err
 }
 
-// loadAuthedUsers reads the file specified by flag_auth to create a list of authorized slack users. The caller can decide whether or not to exit on error.
+// loadAuthedUsers reads the file specified by flagAuth to create a list of authorized slack users. The caller can decide whether or not to exit on error.
 // This function reads from globals (flags)
 func loadAuthedUsers() (ret []string, err error) {
 	var authFile []byte
-	authFile, err = ioutil.ReadFile(*flag_auth)
+	authFile, err = ioutil.ReadFile(*flagAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +106,8 @@ func loadAuthedUsers() (ret []string, err error) {
 // loadSlackTokentries to return a slack key (from flag or file)
 // This function reads from globals (flags)
 func loadSlackToken() (slack string, err error) {
-	if *flag_slack_token == "" {
-		slackFileContents, err := ioutil.ReadFile(*flag_slack_token_file)
+	if *flagSlackToken == "" {
+		slackFileContents, err := ioutil.ReadFile(*flagSlackTokenFile)
 		if err != nil {
 			return "", err
 		}
@@ -122,7 +122,7 @@ func loadSlackToken() (slack string, err error) {
 			slack = strings.TrimSuffix(slack, "\n")
 		}
 	} else {
-		slack = *flag_slack_token
+		slack = *flagSlackToken
 	}
 	return slack, nil
 }
@@ -130,8 +130,8 @@ func loadSlackToken() (slack string, err error) {
 // loadGitHubToken tries to return a github key (from flag or file)
 // This function reads from globals (flags)
 func loadGitHubToken() (github string, err error) {
-	if *flag_github_token == "" {
-		githubFileContents, err := ioutil.ReadFile(*flag_github_token_file)
+	if *flagGitHubToken == "" {
+		githubFileContents, err := ioutil.ReadFile(*flagGitHubTokenFile)
 		if err != nil {
 			return "", err
 		}
@@ -144,7 +144,7 @@ func loadGitHubToken() (github string, err error) {
 			github = strings.TrimSuffix(github, "\n")
 		}
 	} else {
-		github = *flag_slack_token
+		github = *flagSlackToken
 	}
 	return github, nil
 }

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"flag"
+	"github.com/mailgun/log"
+	"os"
+	"io/ioutil"
+	"strings"
+)
+
+// these vars make checking if flags were set easier than using the flag pkg default
+// they can't be const because golang wants to optimize them away but we use their addresses
+var (
+	DEFAULT_SLACK_TOKEN_FILE  = "./slack_token"
+	DEFAULT_GITHUB_TOKEN_FILE = "./github_token"
+)
+
+var (
+	// flag_org is the name of the org the bot has access to
+	flag_org = flag.String("org",
+		"",
+		"Organization bot has access to")
+
+	// flag_auth provides a file by which to load authorized users
+	flag_auth = flag.String("auth",
+		"./userlist",
+		"What file contains a list of authorized users")
+
+	// flag_slack_token will provide a slack token manually
+	flag_slack_token = flag.String("slack_token",
+		"",
+		"Specify the slack token")
+
+	// github_token will provide a github token manually
+	flag_github_token = flag.String("github_token",
+		"",
+		"Specify the github oauth token")
+
+	// flag_slack_token_file will provide a filename for a slack token
+	flag_slack_token_file = flag.String("slack_token_file",
+		"",
+		"Specify the slack token file")
+
+	// github_token_file will provide a filename for a github token
+	flag_github_token_file = flag.String("github_token_file",
+		"",
+		"Specify the github oauth token file")
+)
+
+func flagInit() {
+		// Read the flags in
+		flag.Parse()
+
+		// Now do a basic sanity test on flags.
+		verifyFlagsSanity()
+}
+
+// verifyFlagsSanity just does a basic check on provided flags- are the ones that need to be there, there?
+func verifyFlagsSanity() {
+	if len(*flag_org) == 0 {
+		log.Errorf("You must specify an organization, see --help")
+		defer os.Exit(1)
+	}
+	if *flag_slack_token_file == "" {
+		if *flag_slack_token == "" {
+			flag_slack_token_file = &DEFAULT_SLACK_TOKEN_FILE
+		}
+	} else {
+		if *flag_slack_token != "" {
+			log.Errorf("You must not specify both --flag_slack_token_file AND --flag_slack_token, see --help")
+			defer os.Exit(1)
+		}
+	}
+	if *flag_github_token_file == "" {
+		if *flag_github_token == "" {
+			flag_github_token_file = &DEFAULT_GITHUB_TOKEN_FILE
+		}
+	} else {
+		if *flag_github_token != "" {
+			log.Errorf("You must not specify both --flag_github_token_file AND --flag_github_token, see --help")
+			defer os.Exit(1)
+		}
+	}
+}
+
+// loadAuthedUsers reads the file specified by flag_auth to create a list of authorized slack users. The caller can decide whether or not to exit on error.
+func loadAuthedUsers() (ret []string, err error) {
+	var authFile []byte
+	authFile, err = ioutil.ReadFile(*flag_auth)
+	if err != nil {
+		return nil, err
+	}
+	ret = strings.Split(string(authFile), "\r\n")
+	if len(ret) == 1 { // it's possible that different OSes have different newline conventions- don't check \n first
+		ret = strings.Split(string(authFile), "\n")
+	}
+	return ret, nil
+}
+
+// loadSlackKey tries to return a slack key (from flag or file)
+func loadSlackKey() (slack string, err error) {
+	if *flag_slack_token == "" {
+		slackFileContents, err := ioutil.ReadFile(*flag_slack_token_file)
+		if err != nil {
+			return "", err
+		}
+		slack = string(slackFileContents)
+	} else {
+		slack = *flag_slack_token
+	}
+	return slack, nil
+}
+
+// loadGitHubKey tries to return a github key (from flag or file)
+func loadGitHubKey() (github string, err error) {
+	if *flag_github_token == "" {
+		githubFileContents, err := ioutil.ReadFile(*flag_github_token_file)
+		if err != nil {
+			return "", err
+		}
+		github = string(githubFileContents)
+	} else {
+		github = *flag_slack_token
+	}
+	return github, nil
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	//"fmt"
 	. "gopkg.in/check.v1" // not sure why we went this route (with .) but I'm taking hints from gravitational/hello
 )
 
@@ -27,9 +26,7 @@ func (s *FlagsSuite) TearDownTest(C *C) {
 	// If you want
 }
 
-// test get authed users
-// test get slack key
-// test get github key
+// TODO: comments
 func (s *FlagsSuite) TestVerifyFlags(c *C) {
 	var nilError error = nil
 	testTables := []struct {

--- a/flags_test.go
+++ b/flags_test.go
@@ -15,12 +15,12 @@ func (s *FlagsSuite) SetUpSuite(c *C) {
 }
 
 func (s *FlagsSuite) SetUpTest(c *C) {
-	flag_org = nil
-	flag_auth = nil
-	flag_slack_token = nil
-	flag_slack_token_file = nil
-	flag_github_token = nil
-	flag_github_token_file = nil
+	flagOrg = nil
+	flagAuth = nil
+	flagSlackToken = nil
+	flagSlackTokenFile = nil
+	flagGitHubToken = nil
+	flagGitHubTokenFile = nil
 }
 
 func (s *FlagsSuite) TearDownTest(C *C) {
@@ -45,7 +45,7 @@ func (s *FlagsSuite) TestVerifyFlags(c *C) {
 		{name: "All Errors", org: "", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
 		{name: "No Org", org: "", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "", expected: ErrBadFlag},
 		{name: "All Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
-		{name: "Github Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
+		{name: "GitHub Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
 		{name: "Slack Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "", github_token_file: "fake-github-filename", expected: ErrBadFlag},
 		{name: "All Defaults", org: "fake-org-name", auth: "", slack_token: "", slack_token_file: "", github_token: "", github_token_file: "", expected: nilError},
 		{name: "Best Use w/ Default Auth", org: "fake-org-name", auth: "", slack_token: "", slack_token_file: "fake-test-slack-filename", github_token: "", github_token_file: "fake-github-filename", expected: nilError},
@@ -56,12 +56,12 @@ func (s *FlagsSuite) TestVerifyFlags(c *C) {
 		// setting up comments to go alog with failures
 		comment := Commentf("test #%d (%v)- too many arguments to print", i+1, testTable.name)
 
-		flag_org = &testTable.org
-		flag_auth = &testTable.auth
-		flag_slack_token = &testTable.slack_token
-		flag_slack_token_file = &testTable.slack_token_file
-		flag_github_token = &testTable.github_token
-		flag_github_token_file = &testTable.github_token_file
+		flagOrg = &testTable.org
+		flagAuth = &testTable.auth
+		flagSlackToken = &testTable.slack_token
+		flagSlackTokenFile = &testTable.slack_token_file
+		flagGitHubToken = &testTable.github_token
+		flagGitHubTokenFile = &testTable.github_token_file
 
 		// running actual test
 		err := verifyFlagsSanity()
@@ -77,7 +77,7 @@ func (s *FlagsSuite) TestReadAuth(c *C) {
 	// check against slice
 	c.Skip("Skipping this to move on, but should come back")
 }
-func (s *FlagsSuite) TestReadGithubToken(c *C) {
+func (s *FlagsSuite) TestReadGitHubToken(c *C) {
 	// create a temporary auth file
 	// create auth flag
 	// check against string

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	//"fmt"
+	. "gopkg.in/check.v1" // not sure why we went this route (with .) but I'm taking hints from gravitational/hello
+)
+
+// Check package needs a type
+type FlagsSuite struct{}
+
+var _ = Suite(&FlagsSuite{})
+
+func (s *FlagsSuite) SetUpSuite(c *C) {
+	// If you want
+}
+
+func (s *FlagsSuite) SetUpTest(c *C) {
+	flag_org = nil
+	flag_auth = nil
+	flag_slack_token = nil
+	flag_slack_token_file = nil
+	flag_github_token = nil
+	flag_github_token_file = nil
+}
+
+func (s *FlagsSuite) TearDownTest(C *C) {
+	// If you want
+}
+
+// test get authed users
+// test get slack key
+// test get github key
+func (s *FlagsSuite) TestVerifyFlags(c *C) {
+	var nilError error = nil
+	testTables := []struct {
+		name              string
+		org               string
+		auth              string
+		slack_token       string
+		slack_token_file  string
+		github_token      string
+		github_token_file string
+		expected          error
+	}{ // no org, token and file X2, 5x rational cases
+		{name: "All Errors", org: "", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
+		{name: "No Org", org: "", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "", expected: ErrBadFlag},
+		{name: "All Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
+		{name: "Github Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "fake-github-filename", expected: ErrBadFlag},
+		{name: "Slack Token Redundancy", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "fake-test-slack-filename", github_token: "", github_token_file: "fake-github-filename", expected: ErrBadFlag},
+		{name: "All Defaults", org: "fake-org-name", auth: "", slack_token: "", slack_token_file: "", github_token: "", github_token_file: "", expected: nilError},
+		{name: "Best Use w/ Default Auth", org: "fake-org-name", auth: "", slack_token: "", slack_token_file: "fake-test-slack-filename", github_token: "", github_token_file: "fake-github-filename", expected: nilError},
+		{name: "Best Use w/ Custom Auth", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "", slack_token_file: "fake-test-slack-filename", github_token: "", github_token_file: "fake-github-filename", expected: nilError},
+		{name: "Token Overrides", org: "fake-org-name", auth: "fake-auth-filename", slack_token: "fake-slack-token", slack_token_file: "", github_token: "fake-test-github-token", github_token_file: "", expected: nilError},
+	}
+	for i, testTable := range testTables {
+		// setting up comments to go alog with failures
+		comment := Commentf("test #%d (%v)- too many arguments to print", i+1, testTable.name)
+
+		flag_org = &testTable.org
+		flag_auth = &testTable.auth
+		flag_slack_token = &testTable.slack_token
+		flag_slack_token_file = &testTable.slack_token_file
+		flag_github_token = &testTable.github_token
+		flag_github_token_file = &testTable.github_token_file
+
+		// running actual test
+		err := verifyFlagsSanity()
+
+		// asserting outptus
+		c.Assert(err, Equals, testTable.expected, comment)
+	}
+}
+
+func (s *FlagsSuite) TestReadAuth(c *C) {
+	// create a temporary auth file
+	// create auth flag
+	// check against slice
+	c.Skip("Skipping this to move on, but should come back")
+}
+func (s *FlagsSuite) TestReadGithubToken(c *C) {
+	// create a temporary auth file
+	// create auth flag
+	// check against string
+	// also test with flag token
+	c.Skip("Skipping this to move on, but should come back")
+}
+func (s *FlagsSuite) TestReadSlackToken(c *C) {
+	// create a temporary auth file
+	// create auth flag
+	// check against string
+	// also taken with flag token
+	c.Skip("Skipping this to move on, but should come back")
+}

--- a/github.go
+++ b/github.go
@@ -1,0 +1,4 @@
+package main
+
+import (
+)

--- a/github.go
+++ b/github.go
@@ -13,7 +13,7 @@ var (
 	errNoOrg = errors.New("Either user doesn't have access or org doesn't exist")
 )
 
-// GithubIssuebot is a helper type so we can initialize and call common functions easily
+// GitHubIssuebot is a helper type so we can initialize and call common functions easily
 // TODO: can we do to this what gravitational/hello did for Helloer?
 type GitHubIssueBot struct {
 	client     *githubv4.Client
@@ -63,7 +63,7 @@ func (g *GitHubIssueBot) CheckOrg(org string) (ok bool, err error) { // must pag
 		name = queryUser.User.Name
 	}
 	if err != nil {
-		log.Errorf("Error in CheckOrg() couldn't access supplied org: %T: %v", err, err) // BUG(AJ) Github is kicking back the auth token sometimes, e.g. LOG: -LEGIT TOKEN-\n
+		log.Errorf("Error in CheckOrg() couldn't access supplied org: %T: %v", err, err) // BUG(AJ) GitHub is kicking back the auth token sometimes, e.g. LOG: -LEGIT TOKEN-\n
 		return false, err
 	}
 	log.Debugf("Display Name of %v: %v", org, name)

--- a/github.go
+++ b/github.go
@@ -1,3 +1,179 @@
 package main
 
-import ()
+import (
+	"context"
+	"errors"
+	"github.com/mailgun/log"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+	"net/http"
+)
+
+var (
+	errNoOrg = errors.New("Either user doesn't have access or org doesn't exist")
+)
+
+// GithubIssuebot is a helper type so we can initialize and call common functione easily
+// Not sure it's needed over what githubv4 provides... this will probably need to be an interface
+// TODO: make interface so that we can "dependency inject" for testing
+type GitHubIssueBot struct {
+	client     *githubv4.Client
+	httpClient *http.Client
+	token      string
+	org        string
+}
+
+// NewGitHubIssueBot is basically a tiny initializer
+func NewGitHubIssueBot(token string) (bot *GitHubIssueBot) {
+	// Really bothers me that this declares a pointer AND the value it points to
+	bot = &GitHubIssueBot{
+		token: token,
+	}
+	// Implementation wise, I think returning a pointer puts the value on the heap? This is a pretty standard way of go to do things, but I think from an efficiency perspective it makes more sense to create memory for the value (ie the structure) outside this initialize (in main, for example) and you can avoid the garbage collector
+	return bot
+}
+
+// CheckOrg sanity checks that we can access the organization passed as a parameter. How do I feel about v4? I dont' know.
+func (g *GitHubIssueBot) CheckOrg(org string) (ok bool, err error) { // must paginate, repository
+
+	variables := map[string]interface{}{
+		"org": githubv4.String(org),
+	}
+
+	var name string
+
+	var queryUser struct { // should be search
+		User struct {
+			Name string
+		} `graphql:"user(login: $org)"`
+	}
+
+	var queryOrg struct {
+		Organization struct {
+			Name string
+		} `graphql:"organization(login: $org)"`
+	}
+	// BUG(AJ) So hacky I'll call it a bug. Infact, error handling throughout everything here is crap. Not sure if teams can own repos either.
+
+	err = g.client.Query(context.Background(), &queryUser, variables)
+	if err != nil {
+		err = g.client.Query(context.Background(), &queryOrg, variables)
+		if err == nil {
+			name = queryOrg.Organization.Name
+		}
+	} else {
+		name = queryUser.User.Name
+	}
+	if err != nil {
+		log.Errorf("Error in CheckOrg() couldn't access supplied org: %T: %v", err, err) // BUG(AJ) Github is kicking back the auth token sometimes, e.g. -LEGIT TOKEN-\n
+		return false, err
+	}
+	log.Debugf("Display Name of %v: %v", org, name)
+	g.org = org
+	return true, nil
+
+}
+
+// NewIssue takes a repo, issue, and issueBody and creates a new issue
+func (g *GitHubIssueBot) NewIssue(repo string, title string, body string) (URL string, err error) {
+	variables := map[string]interface{}{
+		"org":  githubv4.String(g.org),
+		"repo": githubv4.String(repo),
+	}
+
+	var query struct {
+		Repository struct {
+			ID githubv4.ID
+		} `graphql:"repository(name: $repo, owner: $org)"`
+	}
+
+	err = g.client.Query(context.Background(), &query, variables)
+
+	if err != nil {
+		log.Errorf("Error in NewIssue() on query: %T: %v", err, err)
+		return "", err
+	}
+
+	type CreateIssueInput struct {
+		Title            githubv4.String  `json:"title"`
+		Body             githubv4.String  `json:"body"`
+		RepositoryId     githubv4.ID      `json:"repositoryId"`
+		ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+	}
+
+	input := CreateIssueInput{
+		Title:        githubv4.String(title),
+		Body:         githubv4.String(body),
+		RepositoryId: query.Repository.ID,
+	}
+
+	var m struct {
+		CreateIssue struct {
+			Issue struct {
+				Url string
+			}
+		} `graphql:"createIssue(input: $input)"`
+	}
+	err = g.client.Mutate(context.Background(), &m, input, nil)
+	if err != nil {
+		log.Errorf("Error in NewIssue() on mutate: %T: %v", err, err)
+		return "", err
+	}
+	return string(m.CreateIssue.Issue.Url), nil
+
+	// TODO: so much other stuff that should go along with posting the issue- assigning it, etc
+}
+
+// Connect just replaces the internal variabels of the GitHubIssueBot structure- so it can be used to reconnect
+// TODO: It should be Disconnect/Reconnecting if not nil but this is okay for now
+func (g *GitHubIssueBot) Connect() (err error) {
+	tokenSrc := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: g.token},
+	)
+	g.httpClient = oauth2.NewClient(context.Background(), tokenSrc)
+
+	// We're wrapping the transport oath2 just gave us with ours from below
+	// but ours is really just a wrapper for the one we just got
+	newTransport := &Transport{RoundTripper: g.httpClient.Transport}
+	g.httpClient.Transport = newTransport
+
+	g.client = githubv4.NewClient(g.httpClient)
+	log.Infof("IssueBot connected to github")
+	return nil
+	//TODO: What errors should be here?
+}
+
+// accept: application/vnd.github.starfire-preview+json
+
+// SetToken is just a setter for the private token member of the type
+func (g *GitHubIssueBot) SetToken(token string) {
+	g.token = token
+}
+
+// type Transport is the weakest wrapper possible over oauth2.Transport (coincidently,
+// it is also a wrapper for http.Transport) to let us add headers to every
+// http roundtrip.
+type Transport struct {
+	http.RoundTripper
+}
+
+// RoundTrip is a wrapper over oauth2.Transport.RoundTrip.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Accept", `application/vnd.github.starfire-preview+json`)
+	return t.RoundTripper.RoundTrip(req)
+}
+
+// TODO: this Transport wrapper would be useful in more contexts (including eliminating middleware in http server)
+// if it had an initialization function that checked if the received Transport was nil and if so making sure
+// to initalize the http.DefaultTransport instead of 1) calling a non-function in RoundTrip and 2) tricking pkg/http which checks
+// if Transport == nil before calling http.DefaultTransport in http.Client.Do()
+
+/*
+Personal Note: This is without a doubt, the Transport wrap, the wildest thing I've done.
+And the mess that is oauth's Transport wrapper over http's Transport makes my eyes bleed.
+http.Client is a structure with a Transport member of interface-type RoundTripper, meaning it must implement RoundTrip().
+Usually http.Client uses it's http.Transport type as a default.
+oauth2.NewClient returns a http.Client which uses it's own Transport type, which is a structure that a) is a http.RoundTripper,
+but b) also contains the original http.Transport as a `base http.Transport` member which it calls in it's own RoundTrip()
+after doing this weird *http.Request mashup - AJ 2018/02/08
+*/

--- a/github.go
+++ b/github.go
@@ -31,6 +31,11 @@ func NewGitHubIssueBot(token string) (bot *GitHubIssueBot) {
 	return bot
 }
 
+// GetOrg() is a getter for the registered org
+func (g *GitHubIssueBot) GetOrg() (org string) {
+	return org
+}
+
 // CheckOrg sanity checks that we can access the organization passed as a parameter. How do I feel about v4? I dont' know.
 func (g *GitHubIssueBot) CheckOrg(org string) (ok bool, err error) { // must paginate, repository
 

--- a/github_test.go
+++ b/github_test.go
@@ -1,3 +1,1 @@
 package main
-
-import ()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ import (
 // Var running is a flag that when set to false, tells all goroutines to exit nicely- and new callbacks not to start (important) network op
 var running = true
 
+// intest lets the supervisor (run) know whether or not to exit
+var intest = false
+
 // Func init() prepares a console logger
 func init() {
 	var level string = "debug"
@@ -71,7 +74,7 @@ func main() {
 	go run(waitForCb)
 
 	// the slackbot library is both block and unsupportive of concurrency
-	err = openBot(slackToken, authedUsers, *flagOrg, waitForCb)
+	err = openBot(slackToken, authedUsers, waitForCb, githubBot)
 
 	if err != nil {
 		log.Errorf("Some problem starting the Slack bot: %v", err)
@@ -109,7 +112,9 @@ func run(waitForCb sync.WaitGroup) {
 
 	waitForCb.Wait()
 
-	os.Exit(0) // Not really happy about this
+	if !intest {
+		os.Exit(0) // Not really happy about this
+	}
 }
 
 // TODO: Refactor this todo list

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	slackToken, err = loadSlackToken() // flags.go
 	if err != nil {
 		log.Errorf("Program couldn't load the Slack token: %v", err)
-		os,Exit(1)
+		os.Exit(1)
 	}
 	var authedUsers []string
 	authedUsers, err = loadAuthedUsers() // flags.go TODO append?
@@ -67,7 +67,7 @@ func main() {
 	run()
 
 	// wait until syncgroup is finished- this isn't preventing a panic-inducing race condition, it's just a courtesy to the users.
-	// That is to say, running could be set to false, and no new coroutines will cause a wait, 
+	// That is to say, running could be set to false, and no new coroutines will cause a wait,
 	// I don't think Wait will get called between a coroutine checking running and calling WaitGroup.Add, but theoretically it can
 	// and that mgiht confuse the user
 	waitForCb.Wait()
@@ -78,7 +78,6 @@ func main() {
 	// wait called
 	// Add(1) called
 	// I guess we could check running again?
-
 
 }
 

--- a/main.go
+++ b/main.go
@@ -35,15 +35,15 @@ func main() {
 	}
 
 	// Prepare GitHub
-	var gitHubToken string
-	gitHubToken, err = loadGitHubToken() // flags.go
+	var githubToken string
+	githubToken, err = loadGitHubToken() // flags.go
 	if err != nil {
 		log.Errorf("Program couldn't load the GitHub token: %v", err)
 		os.Exit(1)
 	}
-	gitHubBot := NewGitHubIssueBot(gitHubToken) // github.go
-	gitHubBot.Connect()
-	if ok, _ := gitHubBot.CheckOrg(*flag_org); !ok {
+	githubBot := NewGitHubIssueBot(githubToken) // github.go
+	githubBot.Connect()
+	if ok, _ := githubBot.CheckOrg(*flagOrg); !ok {
 		log.Errorf("Couldn't load or find the org supplied")
 		os.Exit(1)
 	}
@@ -62,7 +62,8 @@ func main() {
 		os.Exit(1)
 	}
 	// TODO: Init slack with function and callback
-
+	_ = slackToken
+	_ = authedUsers
 	// run will wait for a signal (SIGINTish)
 	run()
 
@@ -88,7 +89,7 @@ func run() {
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt)
 	timeNow := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
-	log.Infof("Issuebot booted for org %v", *flag_org)
+	log.Infof("Issuebot booted for org %v", *flagOrg)
 
 	// Now we're going to wait on signals from terminal
 	for signalRecvd := range signalChannel {

--- a/main.go
+++ b/main.go
@@ -2,97 +2,73 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"github.com/shomali11/slacker"
+	"github.com/mailgun/log"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 )
 
-// running is a flag that when set to false, tells all goroutines to exit nicely
+// running is a flag that when set to false, tells all goroutines to exit nicely- and new callbacks not to start (important) network op
 var running = true
 
-var (
-	// flag_org is the name of the org the bot has access to
-	flag_org = flag.String("org",
-		"",
-		"Organization bot has access to")
 
-	// flag_auth provides a file bywhich to load authorized users
-	flag_auth = flag.String("auth",
-		"./userlist",
-		"What file contains a list of authorized users")
-
-	// flag_slack_token will provide a slack token manually
-	flag_slack_token = flag.String("slack_token",
-		"",
-		"Specify the slack token")
-
-	// github_token will provide a github_token manually
-	flag_github_token = flag.String("github_token",
-		"",
-		"Specify the github oauth token")
-)
-
-// verifyFlagsSanity just does a basic check on provided flags
-func verifyFlagsSanity() {
-	if len(*flag_org) == 0 {
-		fmt.Printf("You must specify an organizatsion, see --help\n")
-		os.Exit(1) // "Panic is for your error, os.Exit is for user error" - Not_a_Golfer
-	}
-}
-
-// init is called automatically by go
-func init() {
-	flag.Usage = func() {
-		fmt.Printf("Usage: issuebot --org=? [optional flags]\n\n")
-		flag.PrintDefaults()
-	}
-	flag.Parse()
-	verifyFlagsSanity()
-}
-
+// main is being used here kind of like a forward declaration- it's the outline of the program.
+// I don't use init because I can't control execution order and so test can't use env variables
 func main() {
-	// TODO: check if files are there?
-	// TODO: check if token files are there if no tokens?
 
-	/*************** NOTES *****************/
-	//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
-	//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
+	// Load a logger- load more later if you want them- some might depend on flags.
+	console, _ := log.NewLogger(log.Config{"console", "debug"}) // note: debug, info, warning, error
+	log.Init(console)
 
-	// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
+	// Be able to turn off flags and verification... these will be called manually
+	if os.Getenv("ISSUEBOT_FLAGS") != "NO" {
+		flagInit() // in flags.go
+	}
 
-	// Slacker type is the api bot and handler
+	// Be able to turn testing and flags off for unit testing- console is fine, obviously
+	if os.Getenv("ISSUEBOT_LOGS") != "NO" {
+		// No other logging enabled (slack logging ?)
+	}
 
-	// new client
-	// new command
-	// register command (example 4/3, 2, 1... parameters, descriptions, etc)
-	// context + listen
-	// ex. 5 respond w/ error
-	// ex. 8 adds a timeout
-	// ex. 12 authorization very simple
-	// ex. 13 default command
+	// TODO: Init github and test
+	// TODO: Init slack with function and callback
 
-	_ = &slacker.CommandDefinition{}
-	/*************** END NOTES AND BS ************/
+	// run will wait for a signal 
+	run()
 
+}
+
+// run sets up both apis with the proper definitions, and then it waits for signals
+func run() {
+
+
+	// This is all for catching signals
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt)
 	timeNow := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
-	fmt.Println("Ready")
+	log.Infof("Issuebot booted for org %v", *flag_org)
+
+	// This is so that we wait for callbacks to finish if we're exiting cleanly
+	var waitForCb sync.WaitGroup
+	// Note: use waitForCb.Add(1) to count an ongoing op and waitForCb.Done() to finish
+
+	// Now we're going to wait on signals from terminal
 	for signalRecvd := range signalChannel {
 		newTime := time.Now()
 		if newTime.Sub(timeNow) < 1000*time.Millisecond {
-			fmt.Printf("\nExiting...\n ")
+			log.Infof("Exiting...")
 			running = false
 			break
 		}
 		timeNow = newTime
-		fmt.Printf("\nReceived a signal: %v\n", signalRecvd)
-		fmt.Printf("Reloading auth'ed users\n")
-		fmt.Printf("Send again <1 second to exit cleanly\n")
+		log.Infof("Received a signal: %v", signalRecvd)
+		log.Infof("Reloading auth'ed users and keys")
+		// TODO: reload authed users and keys- don't panic on error
+		log.Infof("Send again <1 second to exit cleanly")
 	}
+
+	waitForCb.Wait()
 }
 
 // TODO: Refactor this todo list
@@ -101,3 +77,4 @@ func main() {
 // TODO: Could use oauth but oauth reg on github was requiring a larger-scoped registration process (website, etc)- the super benefit of this is that it restrict users to repos they have access to, which would eliminate some of the problems with github's over-scoped token situation (below). This would also allow us to use the suggest log channel as a way to communicate with issues.
 // TODO: the above would change the keyword too
 // TODO: unfortunately, github scopes are _not_ granular. for issues, you get +rw on code, pull reqs, wikis, settings, webhooks, deploy keys. this is a 2yr mega thread on github.com/dear-githu[M#Èb
+// TODO: one way to turn this into an interface would be to create a new bot type that could be initialized with a slack org(s) and github org(s) but I feel like it would just be better to run seperate processes -- although multiple slack orgs and github orgs would be good (although multiple github orgs if users supply their own keys too)

--- a/main.go
+++ b/main.go
@@ -55,10 +55,11 @@ func main() {
 		log.Errorf("Program couldn't load the Slack token: %v", err)
 		os.Exit(1)
 	}
+	log.Debugf("slackToken: %v", slackToken)
 	var authedUsers []string
 	authedUsers, err = loadAuthedUsers() // flags.go TODO append?
 	if err != nil {
-		log.Errorf("Program couldn't load the Slack token: %v", err)
+		log.Errorf("Program couldn't load the authed users: %v", err)
 		os.Exit(1)
 	}
 	// TODO: Init slack with function and callback

--- a/main.go
+++ b/main.go
@@ -1,0 +1,103 @@
+// Package main provides a service-like program, issuebot, that listens to a slack channel and allows users to create new issues on a github repo
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/shomali11/slacker"
+	"os"
+	"os/signal"
+	"time"
+)
+
+// running is a flag that when set to false, tells all goroutines to exit nicely
+var running = true
+
+var (
+	// flag_org is the name of the org the bot has access to
+	flag_org = flag.String("org",
+		"",
+		"Organization bot has access to")
+
+	// flag_auth provides a file bywhich to load authorized users
+	flag_auth = flag.String("auth",
+		"./userlist",
+		"What file contains a list of authorized users")
+
+	// flag_slack_token will provide a slack token manually
+	flag_slack_token = flag.String("slack_token",
+		"",
+		"Specify the slack token")
+
+	// github_token will provide a github_token manually
+	flag_github_token = flag.String("github_token",
+		"",
+		"Specify the github oauth token")
+)
+
+// verifyFlagsSanity just does a basic check on provided flags
+func verifyFlagsSanity() {
+	if len(*flag_org) == 0 {
+		fmt.Printf("You must specify an organizatsion, see --help\n")
+		os.Exit(1) // "Panic is for your error, os.Exit is for user error" - Not_a_Golfer
+	}
+}
+
+// init is called automatically by go
+func init() {
+	flag.Usage = func() {
+		fmt.Printf("Usage: issuebot --org=? [optional flags]\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	verifyFlagsSanity()
+}
+
+func main() {
+	// TODO: check if files are there?
+	// TODO: check if token files are there if no tokens?
+
+	/*************** NOTES *****************/
+	//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
+	//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
+
+	// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
+
+	// Slacker type is the api bot and handler
+
+	// new client
+	// new command
+	// register command (example 4/3, 2, 1... parameters, descriptions, etc)
+	// context + listen
+	// ex. 5 respond w/ error
+	// ex. 8 adds a timeout
+	// ex. 12 authorization very simple
+	// ex. 13 default command
+
+	_ = &slacker.CommandDefinition{}
+	/*************** END NOTES AND BS ************/
+
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, os.Interrupt)
+	timeNow := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
+	fmt.Println("Ready")
+	for signalRecvd := range signalChannel {
+		newTime := time.Now()
+		if newTime.Sub(timeNow) < 1000*time.Millisecond {
+			fmt.Printf("\nExiting...\n ")
+			running = false
+			break
+		}
+		timeNow = newTime
+		fmt.Printf("\nReceived a signal: %v\n", signalRecvd)
+		fmt.Printf("Reloading auth'ed users\n")
+		fmt.Printf("Send again <1 second to exit cleanly\n")
+	}
+}
+
+// TODO: Refactor this todo list
+// TODO: Issue log would be cool on custom response to log channel
+// TODO: It would be cool if you could use a particular user's github credentials from slack but that's a part of a custom auth feature
+// TODO: Could use oauth but oauth reg on github was requiring a larger-scoped registration process (website, etc)- the super benefit of this is that it restrict users to repos they have access to, which would eliminate some of the problems with github's over-scoped token situation (below). This would also allow us to use the suggest log channel as a way to communicate with issues.
+// TODO: the above would change the keyword too
+// TODO: unfortunately, github scopes are _not_ granular. for issues, you get +rw on code, pull reqs, wikis, settings, webhooks, deploy keys. this is a 2yr mega thread on github.com/dear-githu[M#Èb

--- a/main.go
+++ b/main.go
@@ -22,16 +22,30 @@ func init() {
 // I don't use init because I can't control execution order and so test can't use env variables
 func main() {
 
+	var err error
+
 	// This is so that we wait for callbacks to finish if we're exiting cleanly
-	var waitForCb sync.WaitGroup
 	// Note: use waitForCb.Add(1) to count an ongoing op and waitForCb.Done() to finish
+	var waitForCb sync.WaitGroup
 
 	if err := flagInit(); err != nil {
 		log.Errorf("Program couldn't start: %v", err)
 		os.Exit(1)
 	}
 
-	// TODO: Init github and test
+	var gitHubToken string
+	gitHubToken, err = loadGitHubToken()
+	if err != nil {
+		log.Errorf("Program couldn't load the GitHub key: %v", err)
+		os.Exit(1)
+	}
+	gitHubBot := NewGitHubIssueBot(gitHubToken)
+	gitHubBot.Connect()
+	if ok, _ := gitHubBot.CheckOrg(*flag_org); !ok {
+		log.Errorf("Couldn't load or find the org supplied")
+		os.Exit(1)
+	}
+
 	// TODO: Init slack with function and callback
 
 	// run will wait for a signal

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 	//"fmt"
+	catch "github.com/ayjayt/crashtest"
 	. "gopkg.in/check.v1" // not sure why we went this route (with .) but I'm taking hints from gravitational/hello
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"testing"
+	//"fmt"
+	. "gopkg.in/check.v1" // not sure why we went this route (with .) but I'm taking hints from gravitational/hello
+)
+
+func init() {
+	// Default with these off...
+	os.Setenv("ISSUEBOT_FLAGS", "NO")
+	os.Setenv("ISSUEBOT_LOGS", "NO")
+}
+
+// Check package hooks into normal testing
+func TestIssuebot(t *testing.T) { TestingT(t) }
+
+// Check package needs a type
+type IssueBotSuite struct{}
+
+var _ = Suite(&IssueBotSuite{})
+
+func (s *IssueBotSuite) SetUpSuite(c *C) {
+	// If you want
+}
+
+func (s *IssueBotSuite) SetUpTest(c *C) {
+	// If you want
+}
+
+func (s *IssueBotSuite) TearDownTest(C *C) {
+	// If you want
+}
+
+// gravtional/hello had two seperate tests for the Okay input/out and the Erroneus input/out- I combined it into one for no great reason other than to see if I could.
+func (s *IssueBotSuite) TestTableOk(c *C) {
+	// struct of name, parameters and expected outputs
+	// use Commentf, c.Assert
+	// run the function for the whole table
+	var err error = nil
+	c.Assert(err, IsNil)
+}
+
+// No need to do benchmark for this

--- a/main_test.go
+++ b/main_test.go
@@ -1,46 +1,89 @@
 package main
 
 import (
-	"os"
-	"testing"
-	//"fmt"
-	catch "github.com/ayjayt/crashtest"
+	"fmt"
 	. "gopkg.in/check.v1" // not sure why we went this route (with .) but I'm taking hints from gravitational/hello
+	"os"
+	"runtime"
+	"testing"
+	"time"
 )
 
-func init() {
-	// Default with these off...
-	os.Setenv("ISSUEBOT_FLAGS", "NO")
-	os.Setenv("ISSUEBOT_LOGS", "NO")
-}
-
 // Check package hooks into normal testing
-func TestIssuebot(t *testing.T) { TestingT(t) }
+func TestIssueBot(t *testing.T) { TestingT(t) }
 
 // Check package needs a type
-type IssueBotSuite struct{}
+type MainSuite struct{}
 
-var _ = Suite(&IssueBotSuite{})
+var _ = Suite(&MainSuite{})
 
-func (s *IssueBotSuite) SetUpSuite(c *C) {
+func (s *MainSuite) SetUpSuite(c *C) {
 	// If you want
 }
 
-func (s *IssueBotSuite) SetUpTest(c *C) {
-	// If you want
+func (s *MainSuite) SetUpTest(c *C) {
+	running = true
 }
 
-func (s *IssueBotSuite) TearDownTest(C *C) {
-	// If you want
+func (s *MainSuite) TearDownTest(C *C) {
+	running = true
 }
 
-// gravtional/hello had two seperate tests for the Okay input/out and the Erroneus input/out- I combined it into one for no great reason other than to see if I could.
-func (s *IssueBotSuite) TestTableOk(c *C) {
-	// struct of name, parameters and expected outputs
-	// use Commentf, c.Assert
-	// run the function for the whole table
-	var err error = nil
-	c.Assert(err, IsNil)
-}
+// TestProcessFlow just looks to make sure that signals are working properly
+// It's a unique test in that it's not a fn(param...) = return type structure
+func (s *MainSuite) TestRun(c *C) {
 
-// No need to do benchmark for this
+	if runtime.GOOS == "windows" { // TODO: Check, really- see BUG below
+		fmt.Println("You are running on windows. There is a bug that may or may not exist preventing it from running correctly. Please either delete this if block if the test works, or uncomment the line below this print statement if the test does not and submit a pull request or raise an issue.")
+		// c.Skip("Test doesn't work on windows")
+	}
+
+	// Because we can't loop through a table
+	comment := func(stage string) CommentInterface {
+		return Commentf("Run test showed running to be %v when it should be %v %v.", running, !running, stage) // just figured that these variables would be evaluated once when Commentf was called
+	}
+
+	me, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		c.Errorf("Test itself is failing: %v", err)
+		return
+	}
+
+	// Marking the stage
+	c.Assert(running, Equals, true, comment("before running"))
+
+	timeout := time.NewTimer(3 * time.Second)
+	blockChan := make(chan int)
+	go func() {
+		blockChan <- 1
+		run()
+		close(blockChan) // close channel to communicate to goroutine that run finished
+	}()
+
+	<-blockChan                        // Just making sure that coroutine started
+	time.Sleep(200 * time.Millisecond) // Effectively a timeout for the run() coroutine to do it's thing
+
+	// BUG(AJ): This os.Process.Signal(os.Interrupt) wont work on windows? https://github.com/golang/go/issues/6720
+	// It seems that only the test is affected. ^C is interpreted correctly as os.Interrupt when _listening_, but sending os.Interrupt does != ^C on windows
+
+	me.Signal(os.Interrupt)
+	time.Sleep(200 * time.Millisecond) // Signal takes time. Think of 200 ms like a timeout.
+	c.Assert(running, Equals, true, comment("after one signal"))
+
+	me.Signal(os.Interrupt)
+	time.Sleep(200 * time.Millisecond) // Signal takes time. Think of 200 ms like a timeout.
+	c.Assert(running, Equals, false, comment("after a second signal"))
+
+	// Timeout or finish?
+	select {
+	case <-blockChan: // this will be closed if run unblocks
+		if timeout.Stop() { // returns true if succesful stops a timer, I guess
+			return
+		}
+	case <-timeout.C: // this will be "actuated" if the timeout expires
+		c.Error("Test Failure: Timeout. run() never seems to have returned")
+		c.FailNow()
+		return
+	}
+
+}

--- a/slack.go
+++ b/slack.go
@@ -4,25 +4,26 @@ import (
 	"github.com/shomali11/slacker"
 )
 
-	/*************** NOTES *****************/
-	//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
-	//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
+/*************** NOTES *****************/
+//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
+//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
 
-	// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
+// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
 
-	// Slacker type is the api bot and handler
+// Slacker type is the api bot and handler
 
-	// new client
-	// new command
-	// register command (example 4/3, 2, 1... parameters, descriptions, etc)
-	// context + listen
-	// ex. 5 respond w/ error
-	// ex. 8 adds a timeout
-	// ex. 12 authorization very simple
-	// ex. 13 default command
+// new client
+// new command
+// register command (example 4/3, 2, 1... parameters, descriptions, etc)
+// context + listen
+// ex. 5 respond w/ error
+// ex. 8 adds a timeout
+// ex. 12 authorization very simple
+// ex. 13 default command
 
-	func init() {
-		_ = &slacker.CommandDefinition{}
-	}
+func init() {
+	_ = &slacker.CommandDefinition{}
+	// start with example give, and move on
+}
 
-	/*************** END NOTES AND BS ************/
+/*************** END NOTES AND BS ************/

--- a/slack.go
+++ b/slack.go
@@ -1,29 +1,99 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/mailgun/log"
 	"github.com/shomali11/slacker"
+	"strings"
+	"sync"
 )
 
-/*************** NOTES *****************/
-//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
-//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
-
-// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
-
-// Slacker type is the api bot and handler
-
-// new client
-// new command
-// register command (example 4/3, 2, 1... parameters, descriptions, etc)
-// context + listen
-// ex. 5 respond w/ error
-// ex. 8 adds a timeout
-// ex. 12 authorization very simple
-// ex. 13 default command
-
-func init() {
-	_ = &slacker.CommandDefinition{}
-	// start with example give, and move on
+// processParam because the built-in command processor is extremely weak
+func processParam(allParam string) (repo string, title string, body string, ok bool) {
+	// look for three sets of quotes
+	// loop through allParam
+	var threeParams [3]string
+	var paramCount int = 0
+	var quoteSwitch bool = false
+	var escape bool = false
+	var start int = 0
+	log.Debugf("allParam: %v", allParam)
+	for i, c := range allParam {
+		log.Debugf("i, c: %d, %c", i, c)
+		if (i == 0) && (c != '"') { // first character has to be a quote
+			log.Debugf("Bad start to allParam")
+			return "", "", "", false
+		} else if i == 0 { // first character was a quote
+			quoteSwitch = true
+			log.Debugf("Open the quotes!")
+		} else if (!escape) && (c == '\\') { // we'll escape the next character if we weren't escaped
+			escape = true
+			log.Debugf("Next character literal")
+		} else if escape { // turn off escape and move on (we have escaped the current character)
+			escape = false
+			log.Debugf("Character was literal")
+		} else if c == '"' { // we've encountered a non-escaped quote
+			if quoteSwitch { // we were in quotes, now we're out
+				threeParams[paramCount] = allParam[start:i]
+				paramCount += 1
+				log.Debugf("Turn off quotes!")
+			} else { // we are just starting quotes
+				start = i + 1
+				log.Debugf("Turn on quotes!")
+			}
+			quoteSwitch = !quoteSwitch
+		}
+	}
+	if paramCount != 3 {
+		return "", "", "", false
+	}
+	return threeParams[0], threeParams[1], threeParams[2], true
 }
 
-/*************** END NOTES AND BS ************/
+// OpenBot just starts the bot w/ the callback. BUG(AJ) Warning- this bot library doesn't like concurrency. This library is written like we're in node.js.
+func openBot(token string, authedUsers []string, org string, waitForCb sync.WaitGroup) (err error) {
+	var descriptionString strings.Builder
+	descriptionString.WriteString("Creates a new issue on github for ")
+	descriptionString.WriteString(org)
+	descriptionString.WriteString("/YOUR_REPO")
+	_ = authedUsers
+	bot := slacker.NewClient(token)
+	newIssue := &slacker.CommandDefinition{
+		Description: descriptionString.String(),
+		Example:     "new \"repo\" \"issue title\" \"issue body\"",
+
+		// TODO Need custom usage
+		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
+			// This is so that we wait for callbacks to finish if we're exiting cleanly
+			if !running {
+				response.ReportError(errors.New("Issuebot is starting up or shutting down, try again in a few seconds."))
+				// TODO: try to cancel
+				return
+			}
+			waitForCb.Add(1)
+			defer waitForCb.Done()
+			// this supports multiple commands but not "", and I didn't want to override/reimplement the interfaces due to time-cost
+			allParam := request.StringParam("all", "")
+			repo, title, body, ok := processParam(allParam)
+			if !ok {
+				response.ReportError(errors.New("You must specify repo, title, and body for new issue! All in quotes."))
+				return
+			}
+			response.Reply(fmt.Sprintf("You want an issue with a title of: \"%v\" and a body of: \"%v\" on repo: \"%v\"!", title, body, repo))
+			return
+		},
+	}
+
+	bot.Command("new <all>", newIssue)
+
+	// TODO: is this how you turn it off?
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log.Infof("Starting slack bot listen...")
+	err = bot.Listen(ctx) // TODO: This blocks, so how are we going to turn it off?
+	log.Infof("bot.Listen(ctx) returned")
+
+	return err
+}

--- a/slack.go
+++ b/slack.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-// processParam because the built-in command processor is extremely weak
+// processParam processes command parameters manualy because the built-in command processor is extremely weak
 func processParam(allParam string) (repo string, title string, body string, ok bool) {
 	// look for three sets of quotes
 	// loop through allParam
@@ -52,7 +52,7 @@ func processParam(allParam string) (repo string, title string, body string, ok b
 	return threeParams[0], threeParams[1], threeParams[2], true
 }
 
-// OpenBot just starts the bot w/ the callback. BUG(AJ) Warning- this bot library doesn't like concurrency. This library is written like we're in node.js.
+// OpenBot just starts the bot with the callback. BUG(AJ) Warning- this bot library doesn't like concurrency. This library is written like we're in node.js.
 func openBot(token string, authedUsers []string, org string, waitForCb sync.WaitGroup) (err error) {
 	var descriptionString strings.Builder
 	descriptionString.WriteString("Creates a new issue on github for ")
@@ -63,18 +63,14 @@ func openBot(token string, authedUsers []string, org string, waitForCb sync.Wait
 	newIssue := &slacker.CommandDefinition{
 		Description: descriptionString.String(),
 		Example:     "new \"repo\" \"issue title\" \"issue body\"",
-
-		// TODO Need custom usage
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
-			// This is so that we wait for callbacks to finish if we're exiting cleanly
 			if !running {
 				response.ReportError(errors.New("Issuebot is starting up or shutting down, try again in a few seconds."))
-				// TODO: try to cancel
 				return
 			}
 			waitForCb.Add(1)
 			defer waitForCb.Done()
-			// this supports multiple commands but not "", and I didn't want to override/reimplement the interfaces due to time-cost
+			// Note: This supports multiple commands but not "", and I didn't want to override/reimplement the interfaces due to time-cost
 			allParam := request.StringParam("all", "")
 			repo, title, body, ok := processParam(allParam)
 			if !ok {

--- a/slack.go
+++ b/slack.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/shomali11/slacker"
+)
+
+	/*************** NOTES *****************/
+	//BotCommand: Usage() string, Definition() *CommandDefinition, Match(text string) (*proper.Properties, bool), Tokenize() []*commander.Token, Execute(request Request, response ResponseWriter)
+	//CommandDefinition: Description, Example (strings), AuthorizationRequired bool, AuthorizedUsers []string, Handler func(request Request, response responseWriter)
+
+	// the responseWriter you get Reply(text string, option ...ReplyOption), ReportError(err error), Typing(), RTM() *slack.RTM, Client() *slack.Client
+
+	// Slacker type is the api bot and handler
+
+	// new client
+	// new command
+	// register command (example 4/3, 2, 1... parameters, descriptions, etc)
+	// context + listen
+	// ex. 5 respond w/ error
+	// ex. 8 adds a timeout
+	// ex. 12 authorization very simple
+	// ex. 13 default command
+
+	func init() {
+		_ = &slacker.CommandDefinition{}
+	}
+
+	/*************** END NOTES AND BS ************/

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,3 +1,1 @@
 package main
-
-import ()


### PR DESCRIPTION
**Purpose:**

And end-to-end demo of a fully functional "new" command (for posting new issues)

**Implementation:**

Essentially I've connected a wrapped https://github.com/shurcooL/githubv4 and https://github.com/shomali11/slacker to produce this. Slacker takes a githubv4-wrapper bot as a parameter.

**Notes:**

- Slacker uses a blocking callback structure and so it feels less like golang and more like node, and that's a bit painful.
- I didn't see any super-obvious way to further abstract the concepts (e.g. IssueMaker interface and Command interface) but it's worth some thought in the future.

Forthcoming:
- Testing is forthcoming
- Iteration on all comments + inspection w/ Godoc.